### PR TITLE
Update chart to use secret for case ids rather than hardcoding in flux

### DIFF
--- a/et-cron/Chart.yaml
+++ b/et-cron/Chart.yaml
@@ -3,7 +3,7 @@ description: Employment Tribunals cron jobs
 home: https://github.com/hmcts/et-cron
 apiVersion: v2
 appVersion: "1.0"
-version: 0.0.26
+version: 0.0.27
 maintainers:
   - name: HMCTS ET Team
 dependencies:

--- a/et-cron/values.yaml
+++ b/et-cron/values.yaml
@@ -23,6 +23,8 @@ job:
           alias: ET_COS_DB_HOST
         - name: et-cos-postgres-port-v15
           alias: ET_COS_DB_PORT
+        - name: migration-case-ids
+          alias: CRON_RECONFIGURATION_CASE_IDS
     et:
       secrets:
         - name: create-updates-queue-send-connection-string


### PR DESCRIPTION
### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

Update Chart to refer to secret when running cron so case ids do not need to be committed into git